### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add the below to your `book.json` file, then run `gitbook install` :
 
 ```json
 {
-    "plugins": ["plugin-hints"]
+    "plugins": ["hints"]
 }
 ```
 


### PR DESCRIPTION
Plugin should be called `hints` instead of `plugin-hints` other you will get `Error: Registry returned 404 for GET on https://registry.npmjs.org/gitbook-plugin-plugin-hints`